### PR TITLE
yarn.lock: Update caniuse-lite version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,9 +2171,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001087:
-  version "1.0.30001088"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001088.tgz#23a6b9e192106107458528858f2c0e0dba0d9073"
-  integrity sha512-6eYUrlShRYveyqKG58HcyOfPgh3zb2xqs7NvT2VVtP3hEUeeWvc3lqhpeMTxYWBBeeaT9A4bKsrtjATm66BTHg==
+  version "1.0.30001219"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz"
+  integrity sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Based on the following suggestion reported after executing "yarn serve":

  ```
  Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  ```

The "yarn.lock" file was updated accordingly:

```
$ npx browserslist@latest --update-db
Latest version:     1.0.30001219
Installed version:  1.0.30001088
[...]
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 81
+ and_chr 90
- and_ff 68
+ and_ff 87
- android 81
+ android 90
- chrome 83
- chrome 81
- chrome 80
+ chrome 90
+ chrome 89
+ chrome 88
- edge 83
- edge 81
- edge 18
+ edge 90
+ edge 89
- firefox 77
- firefox 76
+ firefox 88
+ firefox 87
+ firefox 86
- ios_saf 13.4-13.5
- ios_saf 13.3
- ios_saf 12.2-12.4
+ ios_saf 14.5
+ ios_saf 14.0-14.4
- op_mob 46
+ op_mob 62
- opera 68
- opera 67
+ opera 75
+ opera 74
- safari 13.1
- safari 13
+ safari 14.1
+ safari 14
- samsung 11.1-11.2
- samsung 10.1
+ samsung 14.0
+ samsung 13.0
```