### PR TITLE
Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@mdi/font": "^5.9.55",
+    "@vue/composition-api": "^1.1.0",
     "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",

--- a/src/components/ActionButton.vue
+++ b/src/components/ActionButton.vue
@@ -49,10 +49,6 @@ export default Vue.extend({
         // TODO: download the extension
       }
     },
-    setInstallState(installState: InstallState) {
-      console.log(`ActionButton - setInstallState [${installState}]`);
-      this.extension.installState = Promise.resolve(installState);
-    },
   },
 
   asyncComputed: {

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -32,6 +32,10 @@ export default Vue.extend({
     };
   },
 
+  activated() {
+    this.os = this.defaultOs;
+  },
+
   computed: {
     hasExtensionManagerModel(): boolean {
       return hasExtensionManagerModel();
@@ -56,20 +60,6 @@ export default Vue.extend({
       ];
     },
   },
-
-  watch: {
-    query(newVal, oldVal) {
-      if (newVal !== oldVal) {
-        this.$emit('update:query', newVal);
-      }
-    },
-    os(newVal, oldVal) {
-      if (newVal !== oldVal) {
-        this.$emit('update:os', newVal);
-      }
-    },
-  },
-
 });
 </script>
 
@@ -82,7 +72,7 @@ export default Vue.extend({
     <v-text-field
       v-if="showQueryField"
       v-model="query"
-      @keyup="$emit('update:query', query);"
+      @input="$emit('update:query', $event);"
       class="shrink mx-4"
       hide-details
       light
@@ -95,12 +85,12 @@ export default Vue.extend({
     <v-spacer></v-spacer>
     <v-select
       v-model="os"
-      @change="$emit('update:os', os);"
+      @change="$emit('update:os', $event);"
       class="shrink mx-4"
       hide-details
       solo
       :items="operatingSystems"
-      >
+    >
       <template v-slot:selection="data">
         <v-list-item-icon><v-icon>{{ data.item.icon }}</v-icon></v-list-item-icon>
         <v-list-item-title>{{ data.item.text }}</v-list-item-title>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,18 @@
 import Vue from 'vue';
 import AsyncComputed from 'vue-async-computed';
 import Notifications from 'vue-notification';
+import CompositionApi from '@vue/composition-api';
 
 import App from './App.vue';
 import vuetify from './plugins/vuetify';
+import bus from './plugins/bus';
 import router from './router';
+import { InstallState } from './lib/api/extension.service';
 
 Vue.config.productionTip = false;
 Vue.use(AsyncComputed);
 Vue.use(Notifications);
+Vue.use(CompositionApi);
 
 const app = new Vue({
   vuetify,
@@ -29,20 +33,13 @@ const app = new Vue({
     search(q: string) {
       /* See https://github.com/vuejs/vetur/issues/1754#issuecomment-595256501 */
       /* eslint-disable @typescript-eslint/no-explicit-any */
-      const view = this.$root.$children[0].$refs.view as any;
+      const view = this.$root.$children[0].$refs.views as any;
       view.query = q;
     },
-    setExtensionButtonState(extensionName: string, installState: string) {
-      const view = this.$root.$children[0].$refs.view as any;
-      view.setExtensionButtonState(extensionName, installState);
+    setExtensionButtonState(extensionName: string, installState: keyof typeof InstallState) {
+      bus.$emit('extension-state-updated', extensionName, InstallState[installState]);
     },
   },
 }).$mount('#app');
-
-declare global {
-  interface Window {
-    app: Vue;
-  }
-}
 
 window.app = app;

--- a/src/plugins/bus.ts
+++ b/src/plugins/bus.ts
@@ -1,0 +1,3 @@
+import Vue from 'vue';
+
+export default new Vue();

--- a/src/shims-tsx.d.ts
+++ b/src/shims-tsx.d.ts
@@ -10,4 +10,7 @@ declare global {
       [elem: string]: any;
     }
   }
+  interface Window {
+    app: Vue;
+  }
 }

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
 import {
-  computed, PropType, ref, defineComponent, Ref, watch, toRefs,
+  computed, PropType, defineComponent, Ref, watch, toRefs, shallowRef,
 } from '@vue/composition-api';
 import { getCategories } from '@/lib/utils';
 import {
-  OS, Arch, Extension, hasExtensionManagerModel, listExtensions, InstallState,
+  OS, Arch, Extension, hasExtensionManagerModel, listExtensions,
 } from '@/lib/api/extension.service';
 
 import Bus from '@/plugins/bus';
@@ -67,7 +67,7 @@ export default defineComponent({
       },
     });
     const propsRefs = toRefs(props);
-    const extensions = ref([]) as Ref<Extension[]>;
+    const extensions = shallowRef([]) as Ref<Extension[]>;
 
     async function loadExtensions() {
       const params = {
@@ -83,14 +83,7 @@ export default defineComponent({
 
     loadExtensions();
 
-    Bus.$on('extension-state-updated', (extensionName: string, state: InstallState) => {
-      extensions.value.forEach((extension) => {
-        if (extensionName === extension.title) {
-          // eslint-disable-next-line no-param-reassign
-          extension.installState = Promise.resolve(state);
-        }
-      });
-    });
+    Bus.$on('extension-state-updated', () => loadExtensions());
 
     watch([propsRefs.revision, propsRefs.os, propsRefs.arch, query], loadExtensions);
 

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -1,17 +1,20 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import {
+  computed, PropType, ref, defineComponent, Ref, watch, toRefs,
+} from '@vue/composition-api';
 import { getCategories } from '@/lib/utils';
 import {
-  OS, Arch, Extension, InstallState, hasExtensionManagerModel, listExtensions,
+  OS, Arch, Extension, hasExtensionManagerModel, listExtensions, InstallState,
 } from '@/lib/api/extension.service';
 
+import Bus from '@/plugins/bus';
 import AppBar from '@/components/AppBar.vue';
 import ExtensionCard from '@/components/ExtensionCard.vue';
 import CategoryList from '@/components/CategoryList.vue';
 
 const AppId = process.env.VUE_APP_APP_ID as string;
 
-export default Vue.extend({
+export default defineComponent({
   props: {
     category: {
       type: String as PropType<string>,
@@ -26,7 +29,7 @@ export default Vue.extend({
       required: true,
     },
     arch: {
-      type: String as PropType<Arch|undefined>,
+      type: String as PropType<Arch | undefined>,
       default: undefined,
     },
   },
@@ -37,129 +40,131 @@ export default Vue.extend({
     ExtensionCard,
   },
 
-  /**
-   * Typescript doesn't support asyncComputed properly.
-   * This section replicates the type declarations of
-   * the actual values in asyncComputed.  Because it's a plugin
-   * asyncComputed's values will override these.
-   */
-  data() {
-    return {
-      extensions: [] as Extension[],
-      query: this.$route.query.q,
-    };
-  },
-
-  asyncComputed: {
-    extensions: {
-      async get(): Promise<Extension[]> {
-        const params = {
-          appId: AppId,
-          revision: parseInt(this.revision, 10),
-          os: this.os,
-          arch: this.arch,
-          query: this.query,
-        };
-        const { data } = await listExtensions(params);
-        this.$router.push({ name: 'Catalog', query: { q: this.query } }).catch((error) => {
+  setup(props, { root }) {
+    const selectedOs = computed({
+      get(): string {
+        return props.os;
+      },
+      set(os: string): void {
+        const { query } = root.$route;
+        root.$router.push({ name: 'Catalog', params: { os }, query }).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;
           }
         });
-        return data;
       },
-      default: [] as Extension[],
-    },
-  },
+    });
+    const query = computed({
+      get(): string {
+        return (root.$route.query.q || '') as string;
+      },
+      set(q: string): void {
+        root.$router.replace({ name: 'Catalog', query: { q } }).catch((error: Error) => {
+          if (error.name !== 'NavigationDuplicated') {
+            throw error;
+          }
+        });
+      },
+    });
+    const propsRefs = toRefs(props);
+    const extensions = ref([]) as Ref<Extension[]>;
 
-  computed: {
-    categories(): [string, number][] {
-      return ([['All', this.extensions.length]] as [string, number][]).concat(getCategories(this.extensions));
-    },
-    filteredExtensions(): Extension[] {
-      if (this.category.toLowerCase() !== 'all') {
-        return this.extensions.filter((e) => e.meta.category === this.category);
+    async function loadExtensions() {
+      const params = {
+        appId: AppId,
+        revision: parseInt(props.revision, 10),
+        os: props.os,
+        arch: props.arch,
+        query: query.value,
+      };
+      const { data } = await listExtensions(params);
+      extensions.value = data;
+    }
+
+    loadExtensions();
+
+    Bus.$on('extension-state-updated', (extensionName: string, state: InstallState) => {
+      extensions.value.forEach((extension) => {
+        if (extensionName === extension.title) {
+          // eslint-disable-next-line no-param-reassign
+          extension.installState = Promise.resolve(state);
+        }
+      });
+    });
+
+    watch([propsRefs.revision, propsRefs.os, propsRefs.arch, query], loadExtensions);
+
+    const categories = computed(() => ((
+      [['All', extensions.value.length]] as [string, number][]).concat(getCategories(extensions.value))));
+
+    const filteredExtensions = computed(() => {
+      if (props.category.toLowerCase() !== 'all') {
+        return extensions.value.filter((e) => e.meta.category === props.category);
       }
-      return this.extensions;
-    },
-    hasExtensionManagerModel(): boolean {
-      return hasExtensionManagerModel();
-    },
-    valid(): string {
-      if (!(this.os in OS)) {
+      return extensions.value;
+    });
+
+    const windowHasExtensionManagerModel = hasExtensionManagerModel();
+
+    const valid = computed(() => {
+      if (!(props.os in OS)) {
         return `Invalid OS.  Choose one of ${Object.keys(OS)}`;
       }
-      if (this.arch !== undefined && !(this.arch in Arch)) {
+      if (props.arch !== undefined && !(props.arch in Arch)) {
         return `Invalid architecutre.  Choose one of ${Object.keys(Arch)}`;
       }
       return '';
-    },
-    selectedOs: {
-      get(): string {
-        return this.$route.params.os;
-      },
-      set(os: string): void {
-        this.$router.push({ name: 'Catalog', params: { os } }).catch((error) => {
-          if (error.name !== 'NavigationDuplicated') {
-            throw error;
-          }
-        });
-      },
-    },
-  },
+    });
 
-  methods: {
-    setExtensionButtonState(extensionName: string, installState: keyof typeof InstallState) {
-      console.log(`Catalog: setExtensionButtonState: ${extensionName} InstallState[${InstallState[installState]}]`);
-    },
-  },
-
-  watch: {
-    query(newVal, oldVal) {
-      if (newVal !== oldVal) {
-        /* See https://github.com/vuejs/vetur/issues/1754#issuecomment-595256501 */
-        /* eslint-disable @typescript-eslint/no-explicit-any */
-        const appbar = this.$refs.appbar as any;
-        appbar.query = newVal;
-      }
-    },
+    return {
+      query,
+      extensions,
+      categories,
+      filteredExtensions,
+      windowHasExtensionManagerModel,
+      valid,
+      selectedOs,
+    };
   },
 });
 </script>
 
 <template>
-<v-container fluid class="catalog">
-  <app-bar
-    ref="appbar"
-    show-query-field
-    class="app-bar"
-    :default-os="os"
-    :default-query="query"
-    :query.sync="query"
-    :os.sync="selectedOs"
-  />
-  <v-row style="height: 100%">
-    <v-col
-      class="flex-grow-0"
-      style="height: 100%"
-    >
-      <category-list
-        class="category-list"
-        :categories="categories"
-      />
-    </v-col>
-    <v-col style="height: 100%">
-      <v-row class="overflow-scroll justify-begin">
-        <extension-card
-          v-for="extension in filteredExtensions"
-          :key="extension._id"
-          v-bind="{ extension }"
-          class="ma-3"
+  <v-container
+    fluid
+    class="catalog"
+  >
+    <app-bar
+      ref="appbar"
+      show-query-field
+      class="app-bar"
+      :default-os="os"
+      :default-query="query"
+      @update:query="query = $event"
+      @update:os="selectedOs = $event"
+    />
+    <v-row style="height: 100%">
+      <v-col
+        class="flex-grow-0"
+        style="height: 100%"
+      >
+        <category-list
+          class="category-list"
+          :categories="categories"
         />
-      </v-row>
-    </v-col>
-  </v-row>
-</v-container>
+      </v-col>
+      <v-col style="height: 100%">
+        <v-row class="overflow-scroll justify-begin">
+          <extension-card
+            v-for="extension in filteredExtensions"
+            :key="extension._id"
+            v-bind="{ extension }"
+            class="ma-3"
+          />
+        </v-row>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <style scoped>

--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
 import {
-  computed, defineComponent, PropType, ref, toRefs, watch,
+  computed, defineComponent, PropType, shallowRef, toRefs, watch,
 } from '@vue/composition-api';
 import {
-  Extension, getExtension, OS, Arch, InstallState,
+  Extension, getExtension, OS, Arch,
 } from '@/lib/api/extension.service';
 import Bus from '@/plugins/bus';
 
@@ -39,7 +39,7 @@ export default defineComponent({
 
   setup(props, { root }) {
     const propsRefs = toRefs(props);
-    const extension = ref(null as Extension | null);
+    const extension = shallowRef(null as Extension | null);
 
     async function loadExtension() {
       extension.value = await getExtension({
@@ -53,9 +53,9 @@ export default defineComponent({
 
     loadExtension();
 
-    Bus.$on('extension-state-updated', (extensionName: string, state: InstallState) => {
+    Bus.$on('extension-state-updated', (extensionName: string) => {
       if (extensionName === extension.value?.title) {
-        extension.value.installState = Promise.resolve(state);
+        loadExtension();
       }
     });
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
-process.env.VUE_APP_APP_ID = process.env.VUE_APP_APP_ID || '5aa3da37f3eb080001497b3d';
-process.env.VUE_APP_BASE_URL = process.env.VUE_APP_BASE_URL || 'http://192.168.113.208:8080/api/v1';
+process.env.VUE_APP_APP_ID = process.env.VUE_APP_APP_ID || '5f4474d0e1d8c75dfc705482';
+process.env.VUE_APP_BASE_URL = process.env.VUE_APP_BASE_URL || 'https://slicer-packages.kitware.com/api/v1';
 
 module.exports = {
   transpileDependencies: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,6 +1346,13 @@
   optionalDependencies:
     prettier "^1.18.2"
 
+"@vue/composition-api@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.1.0.tgz#484e7e3bbc516ad6a9b0a9967d316325c239539e"
+  integrity sha512-9TMJliVFByhfEJjqM+Ymu9ImVrUnrT/Y2S7Fz8EsQ1MbggbE0o8Ohvk9XqK2UIOp8w68f7goVX+6h6O78iRsJQ==
+  dependencies:
+    tslib "^2.3.0"
+
 "@vue/eslint-config-airbnb@^5.1.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@vue/eslint-config-airbnb/-/eslint-config-airbnb-5.3.0.tgz#896551d600816a06dff13fdd7d04fd5153379817"
@@ -8237,6 +8244,11 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslint@^5.20.1:
   version "5.20.1"


### PR DESCRIPTION
Apologies for the larger-than-intended changes.  I needed to modify the `installedState`, which isn't possible with an asyncComputed property, so I had to switch them to deeply reactive state and use a multi-property watcher

Since this is only available in composition api, I had to upgrade to composition api for 2 components.  I haven't really changed much aside from the switch to the new style.

However, because switching from asyncComputed to ref (shallow to deep reactive) added performance issues, I had to use the new compositionApi `shallowRef` and instead of setting the `installedState` property, perform a full reload of the extension details from `manager`

**This means the button change will only work when loaded inside slicer and actually installed.  You can't mock it using the fuction from before**.

You can verify it works by watching the network tab when you issue `app.setExtensionButtonState("GelDosimetryAnalysis", "Installed");`, but without the slicer context, reloading the details will not result in a state change.