### PR TITLE
BUG: Render details page with correct extension metadata

### DIFF
--- a/src/lib/api/extension.service.ts
+++ b/src/lib/api/extension.service.ts
@@ -128,7 +128,8 @@ function getExtension({
       baseName,
       os,
       arch,
-      revision,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      app_revision: revision,
     },
   }).then(({ data }) => {
     if (data.length) {


### PR DESCRIPTION
This commit sets `app_revision` instead of `revision` parameters
with `/app/<app_id>/extension` and ensure the expected extension
metadata are retrieved.