### PR TITLE
BUG: Improve dark theme support

### DIFF
--- a/src/components/ExtensionCard.vue
+++ b/src/components/ExtensionCard.vue
@@ -74,7 +74,7 @@ export default Vue.extend({
       class="text-subtitle-1 font-weight-bold pt-2"
     >
       <router-link
-        class="black--text extension-title"
+        class="extension-title"
         :to="detailsRoute"
       >
         {{ extension.title }}
@@ -101,8 +101,10 @@ $width: 240px;
   height: 475px;
 }
 .extension-title {
+  color: var(--v-primary-darken2);
   white-space: nowrap;
   text-overflow: ellipsis;
+  text-decoration: none;
   overflow: hidden;
 }
 .thumbnail {

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -9,4 +9,7 @@ export default new Vuetify({
   icons: {
     iconfont: 'mdi', // default - only for display purposes
   },
+  theme: {
+    options: { customProperties: true },
+  },
 });


### PR DESCRIPTION
This commit removes the hard-coded color associated with the extension
title and instead associated the "primary-darken2" color.

See https://github.com/Slicer/Slicer/pull/5851