### PR TITLE
Update caniuse-lite from 1.0.30001219 to 1.0.30001282

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2478,9 +2478,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001214:
-  version "1.0.30001219"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz#5bfa5d0519f41f993618bd318f606a4c4c16156b"
-  integrity sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==
+  version "1.0.30001282"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz"
+  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
```
$ npx browserslist@latest --update-db
npx: installed 6 in 2.693s
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Latest version:     1.0.30001282
Installed version:  1.0.30001219
Removing old caniuse-lite from lock file
Installing new caniuse-lite version

$ yarn add -W caniuse-lite
warning " > @vue/eslint-config-airbnb@5.3.0" has unmet peer dependency "eslint-plugin-import@^2.18.2".
warning "@vue/eslint-config-airbnb > eslint-import-resolver-webpack@0.13.0" has unmet peer dependency "webpack@>=1.11.0".
warning " > sass-loader@8.0.2" has unmet peer dependency "webpack@^4.36.0 || ^5.0.0".
warning "vue-cli-plugin-vuetify > null-loader@3.0.0" has unmet peer dependency "webpack@^4.3.0".
warning " > vuetify-loader@1.7.2" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning "vuetify-loader > file-loader@6.2.0" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
Cleaning package.json dependencies from caniuse-lite

$ yarn remove -W caniuse-lite
warning " > @vue/eslint-config-airbnb@5.3.0" has unmet peer dependency "eslint-plugin-import@^2.18.2".
warning "@vue/eslint-config-airbnb > eslint-import-resolver-webpack@0.13.0" has unmet peer dependency "webpack@>=1.11.0".
warning " > sass-loader@8.0.2" has unmet peer dependency "webpack@^4.36.0 || ^5.0.0".
warning "vue-cli-plugin-vuetify > null-loader@3.0.0" has unmet peer dependency "webpack@^4.3.0".
warning " > vuetify-loader@1.7.2" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning "vuetify-loader > file-loader@6.2.0" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 90
+ and_chr 95
- and_ff 87
+ and_ff 92
- android 90
+ android 95
- chrome 90
- chrome 89
- chrome 88
+ chrome 96
+ chrome 95
+ chrome 94
+ chrome 93
- edge 90
- edge 89
+ edge 95
+ edge 94
- firefox 88
- firefox 87
- firefox 86
+ firefox 94
+ firefox 93
- ios_saf 14.5
+ ios_saf 15
+ ios_saf 14.5-14.8
- op_mob 62
+ op_mob 64
- opera 75
- opera 74
+ opera 81
+ opera 80
- safari 14
+ safari 15.1
+ safari 15
- samsung 13.0
+ samsung 15.0
```