### PR TITLE
COMP: Update vue-router to 3.5.4 and limit its version range to patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vue-async-computed": "^3.8.2",
     "vue-gtag": "^1.11.0",
     "vue-notification": "^1.3.8",
-    "vue-router": "^3.3.4",
+    "vue-router": "~3.5.4",
     "vuetify": "^2.6.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8872,10 +8872,10 @@ vue-notification@^1.3.8:
   resolved "https://registry.yarnpkg.com/vue-notification/-/vue-notification-1.3.20.tgz#d85618127763b46f3e25b8962b857947d5a97cbe"
   integrity sha512-vPj67Ah72p8xvtyVE8emfadqVWguOScAjt6OJDEUdcW5hW189NsqvfkOrctxHUUO9UYl9cTbIkzAEcPnHu+zBQ==
 
-vue-router@^3.3.4:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.1.tgz#edf3cf4907952d1e0583e079237220c5ff6eb6c9"
-  integrity sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw==
+vue-router@~3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.4.tgz#c453c0b36bc75554de066fefc3f2a9c3212aca70"
+  integrity sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==
 
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.3"


### PR DESCRIPTION
This prevents a clean install & build from breaking with the following
error when using vue-router v3.6.5:
* https://github.com/KitwareMedical/slicer-extensions-webapp/pull/89

```
 error  in /home/jcfr/Projects/slicer-extensions-webapp/node_modules/vue-router/types/composables.d.ts

ERROR in /home/jcfr/Projects/slicer-extensions-webapp/node_modules/vue-router/types/composables.d.ts(1,15):
1:15 Module '"../../vue/types"' has no exported member 'ComputedRef'. Did you mean to use 'import ComputedRef from "../../vue/types"' instead?
  > 1 | import type { ComputedRef, Ref } from 'vue'
      |               ^
    2 | import type { Route, NavigationGuard, default as VueRouter } from './index'
    3 |
    4 | /**

 error  in /home/jcfr/Projects/slicer-extensions-webapp/node_modules/vue-router/types/composables.d.ts

ERROR in /home/jcfr/Projects/slicer-extensions-webapp/node_modules/vue-router/types/composables.d.ts(1,28):
1:28 Module '"../../vue/types"' has no exported member 'Ref'. Did you mean to use 'import Ref from "../../vue/types"' instead?
  > 1 | import type { ComputedRef, Ref } from 'vue'
      |                            ^
    2 | import type { Route, NavigationGuard, default as VueRouter } from './index'
    3 |
    4 | /**

 ERROR  Build failed with errors.
```