### PR TITLE
STYLE: Specify error type in "catch" calls in ExtensionDetails.vue

### DIFF
--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -87,7 +87,7 @@ export default defineComponent({
       set(os: string): void {
         const { query } = root.$route;
         if (props.legacy) {
-          root.$router.replace({ query: { ...query, os } }).catch((error) => {
+          root.$router.replace({ query: { ...query, os } }).catch((error: Error) => {
             if (error.name !== 'NavigationDuplicated') {
               throw error;
             }
@@ -95,7 +95,7 @@ export default defineComponent({
           return;
         }
         const location = { name: 'Extension Details', params: { os }, query };
-        root.$router.push(location).catch((error) => {
+        root.$router.push(location).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;
           }


### PR DESCRIPTION
This commit fixes "typescript" issues introduced in the following commits:
* 507d8d78 (STYLE: Explicitly push route specifying the component name)
* fe82cebe (ENH: Add legacy routes /slicerappstore and /slicerappstore/extension/view)