### PR TITLE
ENH: Update ExtensionDetails view to render extension description as html

### DIFF
--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -159,7 +159,7 @@ export default defineComponent({
         Last update: {{ new Date(extension.updated).toDateString() }}&nbsp;
         (Revision:&nbsp;<a :href="revisionUrl()">{{ extension.meta.revision.slice(0, 7) }}</a>)
       </div>
-      <div class="text-subtitle-1"> {{ extension.meta.description }} </div>
+      <div class="text-subtitle-1" v-html="extension.meta.description"></div>
       <v-btn
         outlined
         class="my-3 mr-3"


### PR DESCRIPTION
Recommended to install `slicer-package-manager>=0.9.0` integrating the following pull request:
* https://github.com/girder/slicer_package_manager/pull/123