### PR TITLE
COMP: Bump date-and-time from 3.1.1 to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@vue/eslint-config-airbnb": "^5.3.0",
     "@vue/eslint-config-typescript": "^5.1.0",
     "babel-eslint": "^10.1.0",
-    "date-and-time": "^3.1.1",
+    "date-and-time": "^3.6.0",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^6.2.2",
     "git-describe": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3437,10 +3437,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-and-time@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-3.1.1.tgz#70060a97463dd0b3ee5253504956d6d82d5dcda5"
-  integrity sha512-N9kstidT3P0VUk1iKOFilOZ6251r6iTUNx9M9kvgL2jqOk9mljWZUq5CjAtYwCnppWHbERk5YFQUrSbY7FQOpA==
+date-and-time@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-3.6.0.tgz#d78679fbddedf0151dba58ff047e0b64c29225cc"
+  integrity sha512-V99gLaMqNQxPCObBumb31Bfy3OByXnpqUM0yHPi/aBQE61g42A2rGk6Z2CDnpLrWsOFLQwOgl4Vgshw6D44ebw==
 
 de-indent@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
See https://github.com/knowledgecode/date-and-time/compare/v3.1.1..v3.6.0

List of changes:

- 3.6.0
  - In `parseTZ()`, enabled parsing of the missing hour during the transition from standard time to daylight saving time into a Date type.
  - In `format()` with the `z` token, fixed an issue where some short time zone names were incorrect.

- 3.5.0
  - Added `addYearsTZ()`, `addMonthsTZ()`, and `addDaysTZ()` to the `timezone` plugin.
  - Revised the approach to adding time and removed the third parameter from `addHours()`, `addMinutes()`, `addSeconds()`, and `addMilliseconds()`.

- 3.4.1
  - Fixed an issue where `formatTZ()` would output 0:00 as 24:00 in 24-hour format in Node.js.

- 3.4.0
  - Added `zz` (time zone name) and `z` (time zone name abbreviation) tokens to the `timezone` plugin.Add commentMore actions
  - Fixed an issue where token extensions by other plugins were not reflected in functions provided by the `timezone` plugin.

- 3.3.0
  - Refactored `format()`, `isValid()`, and `preparse()`, further improved performance.

- 3.2.0
  - Refactored `compile()`, `format()`, and `preparse()`, slightly improved performance.

- 3.1.1
  - Fixed an issue where `format()` could output incorrect UTC times in locales with daylight savings time.Add commentMore actions
  - Refactored `formatTZ()` of `timezone` plugin.