### PR TITLE
COMP: Bump core-js from 3.6.5 to 3.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@mdi/font": "^7.4.47",
     "@vue/composition-api": "~1.3.3",
     "axios": "^0.21.4",
-    "core-js": "^3.6.5",
+    "core-js": "^3.43.0",
     "vue": "~2.6.14",
     "vue-async-computed": "^3.9.0",
     "vue-gtag": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,6 +3148,11 @@ core-js-compat@^3.25.1, core-js-compat@^3.6.5:
   dependencies:
     browserslist "^4.21.5"
 
+core-js@^3.43.0:
+  version "3.43.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.43.0.tgz#f7258b156523208167df35dea0cfd6b6ecd4ee88"
+  integrity sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==
+
 core-js@^3.6.5:
   version "3.30.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.2.tgz#6528abfda65e5ad728143ea23f7a14f0dcf503fc"


### PR DESCRIPTION
See https://github.com/zloirock/core-js/blob/master/CHANGELOG.md