### PR TITLE
Migrate core components to Composition API in preparation for Vue 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vue-gtag": "^1.16.1",
     "vue-notification": "^1.3.20",
     "vue-router": "~3.5.4",
+    "vue2-helpers": "1",
     "vuetify": "~2.6.15"
   },
   "devDependencies": {
@@ -40,6 +41,9 @@
     "vue-cli-plugin-vuetify": "~2.4.8",
     "vue-template-compiler": "~2.6.14",
     "vuetify-loader": "^1.9.2"
+  },
+  "resolutions": {
+    "@vue/composition-api": "1.3.3"
   },
   "eslintConfig": {
     "root": true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
-import Vue from 'vue';
+import {
+  computed, defineComponent,
+} from '@vue/composition-api';
 import {
   hasExtensionManagerModel,
 } from '@/lib/api/extension.service';
@@ -7,22 +9,21 @@ import {
 const BuildDate = process.env.VUE_APP_BUILD_DATE as string;
 const GitHash = process.env.VUE_APP_GIT_HASH as string;
 
-export default Vue.extend({
+export default defineComponent({
   name: 'App',
 
-  computed: {
-    hasExtensionManagerModel(): boolean {
-      return hasExtensionManagerModel();
-    },
-    buildDate(): string {
-      return BuildDate;
-    },
-    gitRevision(): string {
-      return GitHash.slice(0, 7);
-    },
-    gitRevisionUrl(): string {
-      return `https://github.com/KitwareMedical/slicer-extensions-webapp/commit/${GitHash}`;
-    },
+  setup() {
+    const hasExtensionManagerModelComputed = computed(() => hasExtensionManagerModel());
+    const buildDate = computed(() => BuildDate);
+    const gitRevision = computed(() => GitHash.slice(0, 7));
+    const gitRevisionUrl = computed(() => `https://github.com/KitwareMedical/slicer-extensions-webapp/commit/${GitHash}`);
+
+    return {
+      hasExtensionManagerModel: hasExtensionManagerModelComputed,
+      buildDate,
+      gitRevision,
+      gitRevisionUrl,
+    };
   },
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@ export default Vue.extend({
     buildDate(): string {
       return BuildDate;
     },
-    gitRevison(): string {
+    gitRevision(): string {
       return GitHash.slice(0, 7);
     },
     gitRevisionUrl(): string {
@@ -41,7 +41,7 @@ export default Vue.extend({
       >
         This site is maintained by <a href="https://kitware.com">@Kitware</a> on behalf of the 3D Slicer community.
         <br>This website was last deployed on {{ buildDate }}.
-        Revision <a :href="gitRevisionUrl">{{ gitRevison }}</a>
+        Revision <a :href="gitRevisionUrl">{{ gitRevision }}</a>
       </v-col>
     </v-footer>
   </v-app>

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,8 @@ const BuildDate = process.env.VUE_APP_BUILD_DATE as string;
 const GitHash = process.env.VUE_APP_GIT_HASH as string;
 
 export default Vue.extend({
+  name: 'App',
+
   computed: {
     hasExtensionManagerModel(): boolean {
       return hasExtensionManagerModel();

--- a/src/components/ActionButton.vue
+++ b/src/components/ActionButton.vue
@@ -15,6 +15,8 @@ const defaultButtonOptions: ButtonOptions = {
 };
 
 export default Vue.extend({
+  name: 'ActionButton',
+
   props: {
     extension: {
       type: Object as PropType<Extension>,

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -11,6 +11,8 @@ interface VueSelectItem {
 }
 
 export default Vue.extend({
+  name: 'AppBar',
+
   props: {
     defaultOs: {
       type: String as PropType<string>,

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -14,6 +14,7 @@ export default Vue.extend({
   props: {
     defaultOs: {
       type: String as PropType<string>,
+      required: true,
     },
     defaultQuery: {
       type: String as PropType<string>,
@@ -25,6 +26,10 @@ export default Vue.extend({
     showOperatingSystemSelector: {
       type: Boolean as PropType<boolean>,
       default: true,
+    },
+    legacy: {
+      type: Boolean as PropType<boolean>,
+      default: false,
     },
   },
 

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import {
+  defineComponent, PropType,
+} from '@vue/composition-api';
 import {
   OS, hasExtensionManagerModel,
 } from '@/lib/api/extension.service';
@@ -10,7 +12,7 @@ interface VueSelectItem {
   icon: string;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'AppBar',
 
   props: {

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -1,7 +1,12 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import {
+  defineComponent, PropType,
+} from '@vue/composition-api';
+import {
+  useRoute, useRouter,
+} from 'vue2-helpers/vue-router';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CategoryList',
 
   props: {
@@ -15,11 +20,14 @@ export default Vue.extend({
     },
   },
 
-  methods: {
-    goTo(category: string) {
-      const { query } = this.$route;
-      if (this.legacy) {
-        this.$router.replace({ query: { ...query, category } }).catch((error) => {
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
+
+    const goTo = (category: string) => {
+      const { query } = route;
+      if (props.legacy) {
+        router.replace({ query: { ...query, category } }).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;
           }
@@ -27,15 +35,17 @@ export default Vue.extend({
         return;
       }
       const location = { name: 'Catalog', params: { category }, query: { q: query.q } };
-      this.$router.push(location).catch((error) => {
+      router.push(location).catch((error: Error) => {
         if (error.name !== 'NavigationDuplicated') {
           throw error;
         }
       });
-    },
+    };
+    return { goTo };
   },
 });
 </script>
+
 <template>
   <v-col
     class="pa-0 d-flex flex-column"

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -2,6 +2,8 @@
 import Vue, { PropType } from 'vue';
 
 export default Vue.extend({
+  name: 'CategoryList',
+
   props: {
     categories: {
       type: Array as PropType<[string, number][]>,

--- a/src/components/ExtensionCard.vue
+++ b/src/components/ExtensionCard.vue
@@ -1,13 +1,16 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
-import { Location } from 'vue-router';
+import {
+  defineComponent, PropType, computed,
+} from '@vue/composition-api';
+import {
+  useRoute, useRouter,
+} from 'vue2-helpers/vue-router';
 import { Extension } from '@/lib/api/extension.service';
-
 import ActionButton from '@/components/ActionButton.vue';
 
 const ExtensionDefaultIconUrl = process.env.VUE_APP_EXTENSION_DEFAULT_ICON_URL as string;
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ExtensionCard',
 
   props: {
@@ -27,36 +30,45 @@ export default Vue.extend({
 
   components: { ActionButton },
 
-  computed: {
-    iconUrl(): string {
-      return this.extension.meta.icon_url || ExtensionDefaultIconUrl;
-    },
-    description(): string {
-      const { description } = this.extension.meta;
-      if (description.length > this.maxDescriptionLength) {
-        return description.slice(0, this.maxDescriptionLength).concat('...');
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
+
+    const iconUrl = computed(() => props.extension.meta.icon_url || ExtensionDefaultIconUrl);
+    const description = computed(() => {
+      const desc = props.extension.meta.description;
+      if (desc.length > props.maxDescriptionLength) {
+        return desc.slice(0, props.maxDescriptionLength).concat('...');
       }
-      return this.extension.meta.description;
-    },
-    detailsRoute(): Location {
-      const { currentRoute } = this.$router;
-      if (this.legacy) {
+      return desc;
+    });
+    const detailsRoute = computed(() => {
+      if (props.legacy) {
         return {
           name: 'Extension Details Legacy',
           query: {
-            baseName: this.extension.meta.baseName,
-            ...currentRoute.query,
+            baseName: props.extension.meta.baseName,
+            ...route.query,
           },
         };
       }
       return {
         name: 'Extension Details',
         params: {
-          baseName: this.extension.meta.baseName,
-          ...currentRoute.params,
+          baseName: props.extension.meta.baseName,
+          ...route.params,
         },
       };
-    },
+    });
+    const goToDetails = () => {
+      router.push(detailsRoute.value);
+    };
+    return {
+      iconUrl,
+      description,
+      detailsRoute,
+      goToDetails,
+    };
   },
 });
 </script>

--- a/src/components/ExtensionCard.vue
+++ b/src/components/ExtensionCard.vue
@@ -44,19 +44,25 @@ export default defineComponent({
     });
     const detailsRoute = computed(() => {
       if (props.legacy) {
+        // Remove `category` from query
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { category, ...queryWithoutCategory } = route.query;
         return {
           name: 'Extension Details Legacy',
           query: {
             baseName: props.extension.meta.baseName,
-            ...route.query,
+            ...queryWithoutCategory,
           },
         };
       }
+      // Remove `category` from params
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { category, ...paramsWithoutCategory } = route.params;
       return {
         name: 'Extension Details',
         params: {
           baseName: props.extension.meta.baseName,
-          ...route.params,
+          ...paramsWithoutCategory,
         },
       };
     });

--- a/src/components/ExtensionCard.vue
+++ b/src/components/ExtensionCard.vue
@@ -8,6 +8,8 @@ import ActionButton from '@/components/ActionButton.vue';
 const ExtensionDefaultIconUrl = process.env.VUE_APP_EXTENSION_DEFAULT_ICON_URL as string;
 
 export default Vue.extend({
+  name: 'ExtensionCard',
+
   props: {
     extension: {
       type: Object as PropType<Extension>,

--- a/src/lib/api/extension.service.ts
+++ b/src/lib/api/extension.service.ts
@@ -43,6 +43,7 @@ interface RestExtension {
     repository_url: string;
     revision: string;
     screenshots: string;
+    contributors: string;
   };
 }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,6 @@
-import Vue from 'vue';
-import Router, {
-  Route,
-} from 'vue-router';
+import {
+  createRouter, RouteLocationNormalized,
+} from 'vue2-helpers/vue-router';
 
 import Catalog from '@/views/Catalog.vue';
 import DataStore from '@/views/DataStore.vue';
@@ -9,9 +8,7 @@ import ExtensionDetails from '@/views/ExtensionDetails.vue';
 import Home from '@/views/Home.vue';
 import OperatingSystem from '@/views/OperatingSystem.vue';
 
-Vue.use(Router);
-
-function legacyAppStoreQueryToCatalogProps(route: Route) {
+function legacyAppStoreQueryToCatalogProps(route: RouteLocationNormalized) {
   return {
     category: route.query.category || 'All',
     revision: route.query.revision,
@@ -21,7 +18,7 @@ function legacyAppStoreQueryToCatalogProps(route: Route) {
   };
 }
 
-function legacyAppStoreQueryToExtensionDetailsProps(route: Route) {
+function legacyAppStoreQueryToExtensionDetailsProps(route: RouteLocationNormalized) {
   return {
     baseName: route.query.baseName,
     revision: route.query.revision,
@@ -32,7 +29,7 @@ function legacyAppStoreQueryToExtensionDetailsProps(route: Route) {
   };
 }
 
-export default new Router({
+const router = createRouter({
   mode: 'history',
   routes: [
     {
@@ -86,3 +83,5 @@ export default new Router({
     },
   ],
 });
+
+export default router;

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -2,6 +2,9 @@
 import {
   computed, PropType, defineComponent, Ref, watch, toRefs, shallowRef,
 } from '@vue/composition-api';
+import {
+  useRoute, useRouter,
+} from 'vue2-helpers/vue-router';
 import { getCategories } from '@/lib/utils';
 import {
   OS, Arch, Extension, hasExtensionManagerModel, listExtensions,
@@ -44,9 +47,9 @@ export default defineComponent({
     ExtensionCard,
   },
 
-  setup(props, { root }) {
-    const route = root.$route;
-    const router = root.$router;
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
 
     const selectedOs = computed({
       get(): string {
@@ -73,8 +76,7 @@ export default defineComponent({
 
     const query = computed({
       get(): string {
-        // Explicitly use root.$route as it is a reactive variable
-        return (props.legacy ? root.$route.query.search : root.$route.query.q || '') as string;
+        return (props.legacy ? route.query.search : route.query.q || '') as string;
       },
       set(q: string): void {
         if (props.legacy) {

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -67,6 +67,7 @@ export default defineComponent({
         });
       },
     });
+
     const query = computed({
       get(): string {
         return (props.legacy ? root.$route.query.search : root.$route.query.q || '') as string;
@@ -87,6 +88,7 @@ export default defineComponent({
         });
       },
     });
+
     const propsRefs = toRefs(props);
     const extensions = shallowRef([]) as Ref<Extension[]>;
 
@@ -106,7 +108,12 @@ export default defineComponent({
 
     Bus.$on('extension-state-updated', () => loadExtensions());
 
-    watch([propsRefs.revision, propsRefs.os, propsRefs.arch, query], loadExtensions);
+    watch([
+      propsRefs.revision,
+      propsRefs.os,
+      propsRefs.arch,
+      query,
+    ], loadExtensions);
 
     const categories = computed(() => ((
       [['All', extensions.value.length]] as [string, number][]).concat(getCategories(extensions.value))));

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -18,6 +18,8 @@ import CategoryList from '@/components/CategoryList.vue';
 const AppId = process.env.VUE_APP_APP_ID as string;
 
 export default defineComponent({
+  name: 'CatalogView',
+
   props: {
     category: {
       type: String as PropType<string>,

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -49,17 +49,17 @@ export default defineComponent({
       get(): string {
         return props.os;
       },
-      set(os: string): void {
+      set(newOs: string): void {
         const { query } = root.$route;
         if (props.legacy) {
-          root.$router.push({ name: 'Catalog Legacy', query: { ...query, os } }).catch((error: Error) => {
+          root.$router.push({ name: 'Catalog Legacy', query: { ...query, os: newOs } }).catch((error: Error) => {
             if (error.name !== 'NavigationDuplicated') {
               throw error;
             }
           });
           return;
         }
-        const location = { name: 'Catalog', params: { os }, query };
+        const location = { name: 'Catalog', params: { os: newOs }, query };
         root.$router.push(location).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -45,14 +45,17 @@ export default defineComponent({
   },
 
   setup(props, { root }) {
+    const route = root.$route;
+    const router = root.$router;
+
     const selectedOs = computed({
       get(): string {
         return props.os;
       },
       set(newOs: string): void {
-        const { query } = root.$route;
+        const { query } = route;
         if (props.legacy) {
-          root.$router.push({ name: 'Catalog Legacy', query: { ...query, os: newOs } }).catch((error: Error) => {
+          router.push({ name: 'Catalog Legacy', query: { ...query, os: newOs } }).catch((error: Error) => {
             if (error.name !== 'NavigationDuplicated') {
               throw error;
             }
@@ -60,7 +63,7 @@ export default defineComponent({
           return;
         }
         const location = { name: 'Catalog', params: { os: newOs }, query };
-        root.$router.push(location).catch((error: Error) => {
+        router.push(location).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;
           }
@@ -70,18 +73,19 @@ export default defineComponent({
 
     const query = computed({
       get(): string {
+        // Explicitly use root.$route as it is a reactive variable
         return (props.legacy ? root.$route.query.search : root.$route.query.q || '') as string;
       },
       set(q: string): void {
         if (props.legacy) {
-          root.$router.push({ name: 'Catalog Legacy', query: { ...root.$route.query, search: q } }).catch((error: Error) => {
+          router.push({ name: 'Catalog Legacy', query: { ...route.query, search: q } }).catch((error: Error) => {
             if (error.name !== 'NavigationDuplicated') {
               throw error;
             }
           });
           return;
         }
-        root.$router.replace({ name: 'Catalog', query: { q } }).catch((error: Error) => {
+        router.replace({ name: 'Catalog', query: { q } }).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;
           }

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -122,9 +122,10 @@ export default defineComponent({
     const categories = computed(() => ((
       [['All', extensions.value.length]] as [string, number][]).concat(getCategories(extensions.value))));
 
-    const filteredExtensions = computed(() => {
+    const filteredExtensions = computed((): Extension[] => {
+      const allExtensions = extensions.value;
       if (props.category.toLowerCase() !== 'all') {
-        return extensions.value.filter((e) => e.meta.category === props.category);
+        return allExtensions.filter((e) => e.meta.category === props.category);
       }
       return extensions.value;
     });

--- a/src/views/Catalog.vue
+++ b/src/views/Catalog.vue
@@ -100,7 +100,7 @@ export default defineComponent({
     const propsRefs = toRefs(props);
     const extensions = shallowRef([]) as Ref<Extension[]>;
 
-    async function loadExtensions() {
+    const loadExtensions = async () => {
       const params = {
         appId: AppId,
         revision: parseInt(props.revision, 10),
@@ -110,7 +110,7 @@ export default defineComponent({
       };
       const { data } = await listExtensions(params);
       extensions.value = data;
-    }
+    };
 
     loadExtensions();
 

--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -84,10 +84,8 @@ export default defineComponent({
 
     const selectedOs = computed({
       get(): string {
-        if (props.legacy) {
-          return route.query.os.toString();
-        }
-        return route.params.os;
+        const os = props.legacy ? route.query.os : route.params.os;
+        return typeof os === 'string' ? os : '';
       },
       set(os: string): void {
         const { query } = route;

--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -17,6 +17,8 @@ const AppId = process.env.VUE_APP_APP_ID as string;
 const ExtensionDefaultIconUrl = process.env.VUE_APP_EXTENSION_DEFAULT_ICON_URL as string;
 
 export default defineComponent({
+  name: 'ExtensionDetailsView',
+
   props: {
     baseName: {
       type: String as PropType<string>,

--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     const propsRefs = toRefs(props);
     const extension = shallowRef(null as Extension | null);
 
-    async function loadExtension() {
+    const loadExtension = async () => {
       extension.value = await getExtension({
         appId: AppId,
         baseName: props.baseName,
@@ -66,7 +66,7 @@ export default defineComponent({
         arch: props.arch,
         id: props.id,
       });
-    }
+    };
 
     loadExtension();
 

--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -3,6 +3,9 @@ import {
   computed, defineComponent, PropType, shallowRef, toRefs, watch,
 } from '@vue/composition-api';
 import {
+  useRoute, useRouter,
+} from 'vue2-helpers/vue-router';
+import {
   Extension, getExtension, OS, Arch,
 } from '@/lib/api/extension.service';
 import Bus from '@/plugins/bus';
@@ -46,9 +49,9 @@ export default defineComponent({
     AppBar,
   },
 
-  setup(props, { root }) {
-    const route = root.$route;
-    const router = root.$router;
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
     const propsRefs = toRefs(props);
     const extension = shallowRef(null as Extension | null);
 
@@ -81,11 +84,10 @@ export default defineComponent({
 
     const selectedOs = computed({
       get(): string {
-        // Explicitly use root.$route as it is a reactive variable
         if (props.legacy) {
-          return root.$route.query.os.toString();
+          return route.query.os.toString();
         }
-        return root.$route.params.os;
+        return route.params.os;
       },
       set(os: string): void {
         const { query } = route;

--- a/src/views/ExtensionDetails.vue
+++ b/src/views/ExtensionDetails.vue
@@ -47,6 +47,8 @@ export default defineComponent({
   },
 
   setup(props, { root }) {
+    const route = root.$route;
+    const router = root.$router;
     const propsRefs = toRefs(props);
     const extension = shallowRef(null as Extension | null);
 
@@ -79,15 +81,16 @@ export default defineComponent({
 
     const selectedOs = computed({
       get(): string {
+        // Explicitly use root.$route as it is a reactive variable
         if (props.legacy) {
           return root.$route.query.os.toString();
         }
         return root.$route.params.os;
       },
       set(os: string): void {
-        const { query } = root.$route;
+        const { query } = route;
         if (props.legacy) {
-          root.$router.replace({ query: { ...query, os } }).catch((error: Error) => {
+          router.replace({ query: { ...query, os } }).catch((error: Error) => {
             if (error.name !== 'NavigationDuplicated') {
               throw error;
             }
@@ -95,7 +98,7 @@ export default defineComponent({
           return;
         }
         const location = { name: 'Extension Details', params: { os }, query };
-        root.$router.push(location).catch((error: Error) => {
+        router.push(location).catch((error: Error) => {
           if (error.name !== 'NavigationDuplicated') {
             throw error;
           }

--- a/src/views/OperatingSystem.vue
+++ b/src/views/OperatingSystem.vue
@@ -12,6 +12,8 @@ interface OperatingSystemToRevisionMapping {
 }
 
 export default Vue.extend({
+  name: 'OperatingSystemView',
+
   props: {
     category: {
       type: String as PropType<string>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,7 +1529,7 @@
   optionalDependencies:
     prettier "^1.18.2 || ^2.0.0"
 
-"@vue/composition-api@~1.3.3":
+"@vue/composition-api@1.3.3", "@vue/composition-api@^1.1.0":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.3.3.tgz#a782f2d40e41d4cbb6b4550692c7e01d2182d457"
   integrity sha512-mjhfLjpCBecARYVJX65F0TYerlJQWtEgKjom4Btuu0x7k701EcvL66zyWQryf64HuIj9YR4h6aNRhM0AP/E3eQ==
@@ -9499,7 +9499,15 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@~2.6.14:
+vue2-helpers@1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/vue2-helpers/-/vue2-helpers-1.2.2.tgz#ec8c021330a29ab19592083e7f0fd7b33782b5fe"
+  integrity sha512-/dL4UxX6KvhjB9o9qG5ZG+nUShl6Z02rbPal64olzCLxyEK6v5YCO6OTxzpfrslbUFp6FxTxUP7Ym02m4F+brw==
+  dependencies:
+    "@vue/composition-api" "^1.1.0"
+    vue ">= 2.5 < 2.7"
+
+"vue@>= 2.5 < 2.7", vue@~2.6.14:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==


### PR DESCRIPTION
This pull request introduces a series of enhancements and refactorings focused on modernizing the Vue 2 codebase by adopting Composition API patterns and preparing for a future transition to Vue 3.

### Composition API Migration

* Migrated the following components and views from `Vue.extend` to `defineComponent`:

  * `App`
  * `AppBar`
  * `ActionButton`
  * `ExtensionCard`
  * `CategoryList`
  * `OperatingSystem`
  * `Catalog`
  * `ExtensionDetails`
* Replaced Options API `data`, `computed`, and `methods` with `setup()`-based equivalents for improved readability and type inference.

### Routing Modernization

* Replaced legacy `root.$route` / `root.$router` usage with `useRoute()` and `useRouter()` from `@vue/composition-api` (via `vue2-helpers`).
* Updated router initialization to use `createRouter()` and Composition API–compatible types (`RouteLocationNormalized`), removing reliance on `Vue.use()` and `Route`.

### Bug Fixes

* **Avoid invalid param warnings**: Removed `category` from `route.params` and `route.query` when constructing routes to prevent Vue Router warnings:

  > `[Vue Router warn]: Discarded invalid param(s) "category" when navigating.`
  > [Changelog reference](https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22)

* Added missing `legacy` prop to `AppBar` and marked `defaultOs` as required.
* Fixed a typo in `gitRevision` prop name and ensured `contributors` is present in the `RestExtension` interface.
* Improved type safety in `selectedOs` by replacing unsafe coercion with explicit checks for `string`.

### Code Style & Readability

* Unified function declarations inside `setup()` to use arrow functions (`const foo = () => {}`) for consistency.
* Explicitly set `name` fields for all components.
* Added intermediate variables and whitespace adjustments to improve code clarity and prepare for future refactoring.
